### PR TITLE
Create tables only if they don't exist

### DIFF
--- a/code/sql/fyndiqmodule_setup/install-1.0.0.php
+++ b/code/sql/fyndiqmodule_setup/install-1.0.0.php
@@ -2,56 +2,67 @@
 $installer = $this;
 
 $installer->startSetup();
+$connection = $installer->getConnection();
 
-$productstable = $installer->getConnection()
-    ->newTable($installer->getTable('fyndiq/product'))
-    ->addColumn('id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
-            'identity'  => true,
-            'unsigned'  => true,
-            'nullable'  => false,
-            'primary'   => true,
+// fyndiq_product
+$tableName = $installer->getTable('fyndiq/product');
+if (!$installer->tableExists($tableName)) {
+    $productsTable = $connection->newTable($tableName)
+        ->addColumn('id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+            'identity' => true,
+            'unsigned' => true,
+            'nullable' => false,
+            'primary' => true,
         ), 'Id')
-    ->addColumn('product_id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
-            'nullable'  => false,
+        ->addColumn('product_id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+            'nullable' => false,
         ), 'Magento Product')
-    ->addColumn('exported_price_percentage', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
-            'nullable'  => false,
+        ->addColumn('exported_price_percentage', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+            'nullable' => false,
         ), 'Exported price percentage');
 
-$installer->getConnection()->createTable($productstable);
+    $connection->createTable($productsTable);
+}
 
-$table = $installer->getConnection()
-    ->newTable($installer->getTable('fyndiq/order'))
-    ->addColumn('id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
-            'identity'  => true,
-            'unsigned'  => true,
-            'nullable'  => false,
-            'primary'   => true,
+// fyndiq_order
+$tableName = $installer->getTable('fyndiq/order');
+if (!$installer->tableExists($tableName)) {
+    $table = $connection->newTable($tableName)
+        ->addColumn('id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+            'identity' => true,
+            'unsigned' => true,
+            'nullable' => false,
+            'primary' => true,
         ), 'Id')
-    ->addColumn('order_id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
-            'nullable'  => false,
+        ->addColumn('order_id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+            'nullable' => false,
         ), 'Magento Order')
-    ->addColumn('fyndiq_orderid', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
-            'nullable'  => false,
+        ->addColumn('fyndiq_orderid', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+            'nullable' => false,
         ), 'Fyndiq Order');
 
-$installer->getConnection()->createTable($table);
+    $connection->createTable($table);
+}
 
-$settings = $installer->getConnection()
-    ->newTable($installer->getTable('fyndiq/setting'))
-    ->addColumn('id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
-            'identity'  => true,
-            'unsigned'  => true,
-            'nullable'  => false,
-            'primary'   => true,
+// fyndiq_setting
+$tableName = $installer->getTable('fyndiq/order');
+if (!$installer->tableExists($tableName)) {
+
+    $table = $connection->newTable($tableName)
+        ->addColumn('id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+            'identity' => true,
+            'unsigned' => true,
+            'nullable' => false,
+            'primary' => true,
         ), 'Id')
-    ->addColumn('key', Varien_Db_Ddl_Table::TYPE_TEXT, null, array(
-            'nullable'  => false,
+        ->addColumn('key', Varien_Db_Ddl_Table::TYPE_TEXT, null, array(
+            'nullable' => false,
         ), 'settings key')
-    ->addColumn('value', Varien_Db_Ddl_Table::TYPE_TEXT, null, array(
-            'nullable'  => false,
+        ->addColumn('value', Varien_Db_Ddl_Table::TYPE_TEXT, null, array(
+            'nullable' => false,
         ), 'setting value');
 
-$installer->getConnection()->createTable($settings);
+    $connection->createTable($table);
+}
 
 $installer->endSetup();


### PR DESCRIPTION
Magento runs the module setup on some scope changes and if the setup has already passed it generates an error. This change checks if the tables exist before trying to create them. :scissors: 

/cc @confact 
