### PR TITLE
Add license to the final build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ build: clean
 	sed -i'' 's/XXXXXX/$(COMMIT)/g' $(BUILD_DIR)/src/app/code/community/Fyndiq/Fyndiq/includes/config.php;
 	# mkdir -p $(BUILD_DIR)/src/docs
 	# cp $(DOCS_DIR)/* $(BUILD_DIR)/src/docs
+	cp $(BASE)/LICENSE $(BUILD_DIR)/src/fyndiq/
 	cd $(BUILD_DIR)/src; zip -r -X ../fyndiq-magento-module-v$(MODULE_VERSION)-$(COMMIT).zip .
 	rm -r $(BUILD_DIR)/src
 


### PR DESCRIPTION
Since LICENSE is in the module root, we have to explicitly add it to the module build.

/cc @confact @martkla 
