### PR TITLE
Init translation notifications

### DIFF
--- a/src/app/code/community/Fyndiq/Fyndiq/controllers/NotificationController.php
+++ b/src/app/code/community/Fyndiq/Fyndiq/controllers/NotificationController.php
@@ -11,11 +11,11 @@ class Fyndiq_Fyndiq_NotificationController extends Mage_Core_Controller_Front_Ac
 
     public function indexAction()
     {
+        FyndiqTranslation::init(Mage::app()->getLocale()->getLocaleCode());
         $event = $this->getRequest()->getParam('event');
         $eventName = $event ? $event : false;
         if ($eventName) {
             if ($eventName[0] != '_' && method_exists($this, $eventName)) {
-                FyndiqTranslation::init(Mage::app()->getLocale()->getLocaleCode());
                 return $this->$eventName();
             }
         }


### PR DESCRIPTION
Translation are not initialized for notifications and that causes untranslated messages to appear in the order log.

/cc @confact @martkla 
