### PR TITLE
Allow typing shipping method

### DIFF
--- a/src/app/code/community/Fyndiq/Fyndiq/Model/Carrier.php
+++ b/src/app/code/community/Fyndiq/Fyndiq/Model/Carrier.php
@@ -2,7 +2,9 @@
 
 class Fyndiq_Fyndiq_Model_Carrier extends Mage_Shipping_Model_Carrier_Abstract implements Mage_Shipping_Model_Carrier_Interface
 {
-    protected $_code = 'fyndiq';
+    const METHOD_TITLE = 'Standard';
+
+    protected $_code = 'fyndiq_fyndiq';
 
     /**
      * Get rates of the shipping method
@@ -37,8 +39,8 @@ class Fyndiq_Fyndiq_Model_Carrier extends Mage_Shipping_Model_Carrier_Abstract i
          */
         $rate->setCarrierTitle($this->getConfigData('title'));
 
-        $rate->setMethod('fyndiq');
-        $rate->setMethodTitle('fyndiq');
+        $rate->setMethod('standard');
+        $rate->setMethodTitle(self::METHOD_TITLE);
 
         $rate->setPrice(0);
         $rate->setCost(0);
@@ -54,7 +56,7 @@ class Fyndiq_Fyndiq_Model_Carrier extends Mage_Shipping_Model_Carrier_Abstract i
     public function getAllowedMethods()
     {
         return array(
-            'standard' => 'Standard',
+            'standard' => self::METHOD_TITLE,
         );
     }
 }

--- a/src/app/code/community/Fyndiq/Fyndiq/Model/Order.php
+++ b/src/app/code/community/Fyndiq/Fyndiq/Model/Order.php
@@ -7,7 +7,7 @@ class Fyndiq_Fyndiq_Model_Order extends Mage_Core_Model_Abstract
     const FYNDIQ_ORDERS_NAME_LAST = 'Orders';
 
     const DEFAULT_PAYMENT_METHOD = 'fyndiq_fyndiq';
-    const DEFAULT_SHIPMENT_METHOD = 'fyndiq_fyndiq';
+    const DEFAULT_SHIPMENT_METHOD = 'fyndiq_fyndiq_standard';
 
     public function _construct()
     {

--- a/src/app/code/community/Fyndiq/Fyndiq/etc/config.xml
+++ b/src/app/code/community/Fyndiq/Fyndiq/etc/config.xml
@@ -108,7 +108,7 @@
                 <currency>SEK</currency>
                 <import_orders_disabled>0</import_orders_disabled>
                 <fyndiq_payment_method>fyndiq_fyndiq</fyndiq_payment_method>
-                <fyndiq_shipment_method>fyndiq_fyndiq</fyndiq_shipment_method>
+                <fyndiq_shipment_method>fyndiq_fyndiq_standard</fyndiq_shipment_method>
             </fyndiq_group>
         </fyndiq>
         <carriers>

--- a/src/app/code/community/Fyndiq/Fyndiq/etc/system.xml
+++ b/src/app/code/community/Fyndiq/Fyndiq/etc/system.xml
@@ -36,7 +36,8 @@
                             <comment>
                                 <![CDATA[Leave the field empty for the default Fyndiq shipping method]]>
                             </comment>
-                            <frontend_type>text</frontend_type>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_shipping_allmethods</source_model>
                             <sort_order>17</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>


### PR DESCRIPTION
Allow merchant to manually type the shipping method code.
If empty the Fyndiq one will be used. If wrong the first one will be used.

/cc @confact 
