### PR TITLE
Fix translation helper

### DIFF
--- a/src/app/code/community/Fyndiq/Fyndiq/Helper/Data.php
+++ b/src/app/code/community/Fyndiq/Fyndiq/Helper/Data.php
@@ -7,8 +7,10 @@ class Fyndiq_Fyndiq_Helper_Data extends Mage_Core_Helper_Abstract
 {
     private $loaded = false;
 
-    public function __($string)
+    public function __()
     {
+        $args = func_get_args();
+        $string = array_shift($args);
         if (!$string) {
             return '';
         }


### PR DESCRIPTION
the `__()` interface must be the same as in the abstract class.

@confact 
