### PR TITLE
Don't drop the tables on upgrade

### DIFF
--- a/src/app/code/community/Fyndiq/Fyndiq/sql/fyndiqmodule_setup/upgrade-1.0.8-2.0.0.php
+++ b/src/app/code/community/Fyndiq/Fyndiq/sql/fyndiqmodule_setup/upgrade-1.0.8-2.0.0.php
@@ -110,8 +110,6 @@ if ($installer2->tableExists($productTableName)) {
                 ->saveAttribute($product, 'fyndiq_exported');
         }
     }
-    $sql = 'DROP TABLE IF EXISTS ' . $productTableName;
-    $installer2->run($sql);
 }
 $installer2->endSetup();
 
@@ -153,7 +151,5 @@ if ($installer2->tableExists($orderTableName)) {
             $order->save();
         }
     }
-    $sql = 'DROP TABLE IF EXISTS ' . $orderTableName;
-    $installerOrder->run($sql);
 }
 $installerOrder->endSetup();


### PR DESCRIPTION
We decided not to delete the `1.0.*` tables when upgrading to `2.*` to allow the merchants to revert to the previous version, if required.

@confact  
