### PR TITLE
Get sales table name from Magento

### DIFF
--- a/src/app/code/community/Fyndiq/Fyndiq/Block/Adminhtml/Fyndiq/Order/Grid.php
+++ b/src/app/code/community/Fyndiq/Fyndiq/Block/Adminhtml/Fyndiq/Order/Grid.php
@@ -34,9 +34,10 @@ class Fyndiq_Fyndiq_Block_Adminhtml_Fyndiq_Order_Grid extends Mage_Adminhtml_Blo
 
     public function setCollection($collection)
     {
+        $tableName = Mage::getSingleton('core/resource')->getTableName('sales/order');
         $collection->getSelect()->columns(
             array(
-                'fyndiq_order_id' => '(SELECT fyndiq_order_id FROM sales_flat_order sfo WHERE sfo.entity_id = main_table.entity_id)'
+                'fyndiq_order_id' => '(SELECT fyndiq_order_id FROM ' . $tableName . ' sfo WHERE sfo.entity_id = main_table.entity_id)'
             )
         );
         parent::setCollection($collection);

--- a/src/app/code/community/Fyndiq/Fyndiq/Block/Adminhtml/Sales/Order/Grid.php
+++ b/src/app/code/community/Fyndiq/Fyndiq/Block/Adminhtml/Sales/Order/Grid.php
@@ -60,9 +60,10 @@ class Fyndiq_Fyndiq_Block_Adminhtml_Sales_Order_Grid extends Mage_Adminhtml_Bloc
     public function setCollection($collection)
     {
         if (!$this->isEnabled($this->getStoreId())) {
+            $tableName = Mage::getSingleton('core/resource')->getTableName('sales/order');
             $collection->getSelect()->columns(
                 array(
-                    'fyndiq_order_id' => '(SELECT fyndiq_order_id FROM sales_flat_order sfo WHERE sfo.entity_id = main_table.entity_id)'
+                    'fyndiq_order_id' => '(SELECT fyndiq_order_id FROM ' . $tableName . ' sfo WHERE sfo.entity_id = main_table.entity_id)'
                 )
             );
         }

--- a/src/app/code/community/Fyndiq/Fyndiq/data/fyndiqmodule_setup/data-upgrade-1.0.8-2.0.0.php
+++ b/src/app/code/community/Fyndiq/Fyndiq/data/fyndiqmodule_setup/data-upgrade-1.0.8-2.0.0.php
@@ -43,7 +43,7 @@ if ($installer->tableExists($productTableName)) {
                     ->setData('fyndiq_exported', 1)
                     ->getResource()
                     ->saveAttribute($product, 'fyndiq_exported');
-            } catch (Exception $e){
+            } catch (Exception $e) {
                 Mage::log($e->getMessage(), Zend_Log::ERR);
             }
         }


### PR DESCRIPTION
Table names can very depending on table prefix, so we cannot rely on it being the same for every installation.
