### PR TITLE
Remove explicit store filter on export

### DIFF
--- a/src/app/code/community/Fyndiq/Fyndiq/Model/Export.php
+++ b/src/app/code/community/Fyndiq/Fyndiq/Model/Export.php
@@ -417,7 +417,6 @@ class Fyndiq_Fyndiq_Model_Export
     protected function getCategoryFyndiqId($storeId, $categoryId)
     {
         $category = Mage::getModel('catalog/category')
-            ->setStoreId($storeId)
             ->load($categoryId);
         return $category->getFyndiqCategoryId();
     }


### PR DESCRIPTION
Remove explicit store filter on export, to prevent export from crashing default scope with flat categories.
